### PR TITLE
Add tag_name to update_release documentation

### DIFF
--- a/lib/octokit/client/releases.rb
+++ b/lib/octokit/client/releases.rb
@@ -44,6 +44,7 @@ module Octokit
       # Update a release
       #
       # @param url [String] URL for the release as returned from .releases
+      # @option options [String] :tag_name Git tag from which to create release
       # @option options [String] :target_commitish Specifies the commitish value that determines where the Git tag is created from.
       # @option options [String] :name Name for the release
       # @option options [String] :body Content for release notes


### PR DESCRIPTION
The [edit_release](https://developer.github.com/v3/repos/releases/#edit-a-release) endpoint accepts a tag_name so that should be documented here.

Furthermore, when using the `update_release` method without specifying a tag_name, the tag in Github is overwritten. 

For example, my tag was "v4.0" and after calling `update_release` without a tag name it became "untagged-{commit-hash}".